### PR TITLE
Updated styles.css - normal font is 400

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -61,7 +61,7 @@ h2 {
 }
 
 .Regular {
-    font-weight: 500;
+    font-weight: 400;
 }
 
 .Semibold {


### PR DESCRIPTION
I thought the 'Regular' weight looked too heavy in the demo until I checked that its set to `font-weight: 500`. Setting it to `400` looks correct.