### PR TITLE
Correct `format()` in `source-serif-variable.css`

### DIFF
--- a/source-serif-variable.css
+++ b/source-serif-variable.css
@@ -3,9 +3,9 @@
     font-weight: 200 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('./WOFF2/VAR/SourceSerif4Variable-Roman.ttf.woff2') format('woff2'),
-         url('./WOFF/VAR/SourceSerif4Variable-Roman.ttf.woff') format('woff'),
-         url('./VAR/SourceSerif4Variable-Roman.ttf') format('truetype');
+    src: url('./WOFF2/VAR/SourceSerif4Variable-Roman.ttf.woff2') format('woff2-variations'),
+         url('./WOFF/VAR/SourceSerif4Variable-Roman.ttf.woff') format('woff-variations'),
+         url('./VAR/SourceSerif4Variable-Roman.ttf') format('truetype-variations');
 }
 
 @font-face{
@@ -13,7 +13,7 @@
     font-weight: 200 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('./WOFF2/VAR/SourceSerif4Variable-Italic.ttf.woff2') format('woff2'),
-         url('./WOFF/VAR/SourceSerif4Variable-Italic.ttf.woff') format('woff'),
-         url('./VAR/SourceSerif4Variable-Italic.ttf') format('truetype');
+    src: url('./WOFF2/VAR/SourceSerif4Variable-Italic.ttf.woff2') format('woff2-variations'),
+         url('./WOFF/VAR/SourceSerif4Variable-Italic.ttf.woff') format('woff-variations'),
+         url('./VAR/SourceSerif4Variable-Italic.ttf') format('truetype-variations');
 }


### PR DESCRIPTION
This is required to let browsers that don’t support variable fonts (e.g. Firefox on Windows 8) avoid downloading them and fall back to something usable.